### PR TITLE
VST: Dexed

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Audio Plugins
 | OwlBass | https://github.com/PentagramPro/OwlBass | Additive bass synth |
 | Argotlunar | https://github.com/mourednik/argotlunar | Real-time delay-line granulator |
 | LameVST | https://github.com/Iunusov/LameVST | LameMP3 as an effect |
+| Dexed | https://github.com/asb2m10/dexed | DX7 FM plugin synth |
 
 Collections
 -----------


### PR DESCRIPTION
I noticed this pretty popular open source FM synth hasn't added here yet

GitHub: https://github.com/asb2m10/dexed
Website: http://asb2m10.github.io/dexed/