### PR TITLE
Better linkification, description in separate column, more info

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,23 +13,23 @@ https://openaudio.webprofusion.com
 Audio Plugins
 ----------
 
-| Plugin | Description | Framework |
-| --- | --- | --- |
-| [airwindows](https://github.com/airwindows/airwindows) | Various small and experimental effect plugins | ? |
-| [Argotlunar](https://github.com/mourednik/argotlunar) | Real-time delay-line granulator | JUCE |
-| [Cocoa Delay](https://github.com/tesselode/cocoa-delay) | Warm and lively delay plugin | wdl-ol |
-| [Dexed](https://github.com/asb2m10/dexed) | DX7 FM plugin synth | JUCE |
-| [Dragonfly Reverb](https://github.com/michaelwillis/dragonfly-reverb) | A free hall-style reverb based on freeverb3 algorithms | DPF |
-| [Eurorack](https://github.com/VCVRack/AudibleInstruments) | A diverse set of physical modeling sources, organic processors, wavetable oscillators, waveshapers, granular synthesizers, and utility modules | ? |
-| [Flutterbird](https://github.com/tesselode/flutterbird) | Simple pitch fluctuation | iPlug 2 |
-| [Helm](https://github.com/mtytel/helm) | A free polyphonic synth with lots of modulation | JUCE |
-| [LameVST](https://github.com/Iunusov/LameVST) | LameMP3 as an effect | ? |
-| [mda](https://sourceforge.net/projects/mda-vst/) | A collection of FX and virtual instruments for PC and Mac | ? |
-| [Mika Micro](https://github.com/tesselode/mika-micro) | A simple subtractive synth plugin | wdl-ol |
-| [OwlBass](https://github.com/PentagramPro/OwlBass) | Additive bass synth | JUCE |
-| [regrader](https://github.com/igorski/regrader) | A degenerative delay plugin | ~VSTGUI |
-| [Surge](https://surge-synthesizer.github.io/) | Subtractive wavetable synth | VSTGUI |
-| [Synister](https://github.com/the-synister/the-source) | Subtractive software synth | JUCE |
+| Plugin | Description | Type | Framework |
+| --- | --- | --- | --- |
+| [airwindows](https://github.com/airwindows/airwindows) | Various small and experimental effect plugins | Effect | ? |
+| [Argotlunar](https://github.com/mourednik/argotlunar) | Real-time delay-line granulator | Effect | JUCE |
+| [Cocoa Delay](https://github.com/tesselode/cocoa-delay) | Warm and lively delay plugin | Effect | wdl-ol |
+| [Dexed](https://github.com/asb2m10/dexed) | DX7 FM plugin synth | Instrument | JUCE |
+| [Dragonfly Reverb](https://github.com/michaelwillis/dragonfly-reverb) | A free hall-style reverb based on freeverb3 algorithms | Effect | DPF |
+| [Eurorack](https://github.com/VCVRack/AudibleInstruments) | A diverse set of physical modeling sources, organic processors, wavetable oscillators, waveshapers, granular synthesizers, and utility modules | Misc | ? |
+| [Flutterbird](https://github.com/tesselode/flutterbird) | Simple pitch fluctuation | Effect | iPlug 2 |
+| [Helm](https://github.com/mtytel/helm) | A free polyphonic synth with lots of modulation | Instrument | JUCE |
+| [LameVST](https://github.com/Iunusov/LameVST) | LameMP3 as an effect | Effect | ? |
+| [mda](https://sourceforge.net/projects/mda-vst/) | A collection of FX and virtual instruments for PC and Mac | Misc | ? |
+| [Mika Micro](https://github.com/tesselode/mika-micro) | A simple subtractive synth plugin | Instrument | wdl-ol |
+| [OwlBass](https://github.com/PentagramPro/OwlBass) | Additive bass synth | Instrument | JUCE |
+| [regrader](https://github.com/igorski/regrader) | A degenerative delay plugin | Effect | ~VSTGUI |
+| [Surge](https://surge-synthesizer.github.io/) | Subtractive wavetable synth | Instrument | VSTGUI |
+| [Synister](https://github.com/the-synister/the-source) | Subtractive software synth | Instrument | JUCE |
 
 Collections
 -----------

--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ Audio Plugins
 | --- | --- | --- | --- |
 | [airwindows](https://github.com/airwindows/airwindows) | Various small and experimental effect plugins | Effect | ? |
 | [Argotlunar](https://github.com/mourednik/argotlunar) | Real-time delay-line granulator | Effect | JUCE |
-| [Cocoa Delay](https://github.com/tesselode/cocoa-delay) | Warm and lively delay plugin | Effect | wdl-ol |
+| [Cocoa Delay](https://github.com/tesselode/cocoa-delay) | Warm and lively delay | Effect | wdl-ol |
 | [Dexed](https://github.com/asb2m10/dexed) | DX7 FM plugin synth | Instrument | JUCE |
-| [Dragonfly Reverb](https://github.com/michaelwillis/dragonfly-reverb) | A free hall-style reverb based on freeverb3 algorithms | Effect | DPF |
-| [Eurorack](https://github.com/VCVRack/AudibleInstruments) | A diverse set of physical modeling sources, organic processors, wavetable oscillators, waveshapers, granular synthesizers, and utility modules | Misc | ? |
+| [Dragonfly Reverb](https://github.com/michaelwillis/dragonfly-reverb) | Hall-style reverb based on freeverb3 algorithms | Effect | DPF |
+| [Eurorack](https://github.com/VCVRack/AudibleInstruments) | Diverse set of physical modeling sources, organic processors, wavetable oscillators, waveshapers, granular synthesizers, and utility modules | Misc | ? |
 | [Flutterbird](https://github.com/tesselode/flutterbird) | Simple pitch fluctuation | Effect | iPlug 2 |
-| [Helm](https://github.com/mtytel/helm) | A free polyphonic synth with lots of modulation | Instrument | JUCE |
+| [Helm](https://github.com/mtytel/helm) | Polyphonic synth with lots of modulation | Instrument | JUCE |
 | [LameVST](https://github.com/Iunusov/LameVST) | LameMP3 as an effect | Effect | ? |
-| [mda](https://sourceforge.net/projects/mda-vst/) | A collection of FX and virtual instruments for PC and Mac | Misc | ? |
-| [Mika Micro](https://github.com/tesselode/mika-micro) | A simple subtractive synth plugin | Instrument | wdl-ol |
+| [mda](https://sourceforge.net/projects/mda-vst/) | FX and virtual instruments for PC and Mac | Misc | ? |
+| [Mika Micro](https://github.com/tesselode/mika-micro) | Simple subtractive synth | Instrument | wdl-ol |
 | [OwlBass](https://github.com/PentagramPro/OwlBass) | Additive bass synth | Instrument | JUCE |
-| [regrader](https://github.com/igorski/regrader) | A degenerative delay plugin | Effect | ~VSTGUI |
+| [regrader](https://github.com/igorski/regrader) | Degenerative delay | Effect | ~VSTGUI |
 | [Surge](https://surge-synthesizer.github.io/) | Subtractive wavetable synth | Instrument | VSTGUI |
 | [Synister](https://github.com/the-synister/the-source) | Subtractive software synth | Instrument | JUCE |
 

--- a/README.md
+++ b/README.md
@@ -13,23 +13,23 @@ https://openaudio.webprofusion.com
 Audio Plugins
 ----------
 
-| Plugin | Description |
-| --- | --- |
-| [airwindows](https://github.com/airwindows/airwindows) | Various small and experimental effect plugins |
-| [Argotlunar](https://github.com/mourednik/argotlunar) | Real-time delay-line granulator |
-| [Cocoa Delay](https://github.com/tesselode/cocoa-delay) | Warm and lively delay plugin |
-| [Dexed](https://github.com/asb2m10/dexed) | DX7 FM plugin synth |
-| [Dragonfly Reverb](https://github.com/michaelwillis/dragonfly-reverb) | A free hall-style reverb based on freeverb3 algorithms |
-| [Eurorack](https://github.com/VCVRack/AudibleInstruments) | A diverse set of physical modeling sources, organic processors, wavetable oscillators, waveshapers, granular synthesizers, and utility modules |
-| [Flutterbird](https://github.com/tesselode/flutterbird) | Simple pitch fluctuation |
-| [Helm](https://github.com/mtytel/helm) | a free polyphonic synth with lots of modulation |
-| [LameVST](https://github.com/Iunusov/LameVST) | LameMP3 as an effect |
-| [mda](https://sourceforge.net/projects/mda-vst/) | A collection of FX and virtual instruments for PC and Mac |
-| [Mika Micro](https://github.com/tesselode/mika-micro) | A simple subtractive synth plugin |
-| [OwlBass](https://github.com/PentagramPro/OwlBass) | Additive bass synth |
-| [regrader](https://github.com/igorski/regrader) | A degenerative delay plugin |
-| [Surge](https://surge-synthesizer.github.io/) | Subtractive wavetable synth |
-| [Synister](https://github.com/the-synister/the-source) | Subtractive software synth |
+| Plugin | Description | Framework |
+| --- | --- | --- |
+| [airwindows](https://github.com/airwindows/airwindows) | Various small and experimental effect plugins | ? |
+| [Argotlunar](https://github.com/mourednik/argotlunar) | Real-time delay-line granulator | JUCE |
+| [Cocoa Delay](https://github.com/tesselode/cocoa-delay) | Warm and lively delay plugin | wdl-ol |
+| [Dexed](https://github.com/asb2m10/dexed) | DX7 FM plugin synth | JUCE |
+| [Dragonfly Reverb](https://github.com/michaelwillis/dragonfly-reverb) | A free hall-style reverb based on freeverb3 algorithms | DPF |
+| [Eurorack](https://github.com/VCVRack/AudibleInstruments) | A diverse set of physical modeling sources, organic processors, wavetable oscillators, waveshapers, granular synthesizers, and utility modules | ? |
+| [Flutterbird](https://github.com/tesselode/flutterbird) | Simple pitch fluctuation | iPlug 2 |
+| [Helm](https://github.com/mtytel/helm) | a free polyphonic synth with lots of modulation | JUCE |
+| [LameVST](https://github.com/Iunusov/LameVST) | LameMP3 as an effect | ? |
+| [mda](https://sourceforge.net/projects/mda-vst/) | A collection of FX and virtual instruments for PC and Mac | ? |
+| [Mika Micro](https://github.com/tesselode/mika-micro) | A simple subtractive synth plugin | wdl-ol |
+| [OwlBass](https://github.com/PentagramPro/OwlBass) | Additive bass synth | JUCE |
+| [regrader](https://github.com/igorski/regrader) | A degenerative delay plugin | ~VSTGUI |
+| [Surge](https://surge-synthesizer.github.io/) | Subtractive wavetable synth | VSTGUI |
+| [Synister](https://github.com/the-synister/the-source) | Subtractive software synth | JUCE |
 
 Collections
 -----------

--- a/README.md
+++ b/README.md
@@ -13,62 +13,59 @@ https://openaudio.webprofusion.com
 Audio Plugins
 ----------
 
-| Plugin | Website | Description
-| --- | --- |--- |
-| mda | https://sourceforge.net/projects/mda-vst/ | A collection of FX and virtual instruments for PC and Mac |
-| Synister | https://github.com/the-synister/the-source | Subtractive software synth |
-| Surge Synthesizer | https://surge-synthesizer.github.io/ | Subtractive wavetable synth |
-| Eurorack |  https://github.com/VCVRack/AudibleInstruments | A diverse set of physical modeling sources, organic processors, wavetable oscillators, waveshapers, granular synthesizers, and utility modules |
-| Helm | https://github.com/mtytel/helm | a free polyphonic synth with lots of modulation |
-| Dragonfly Reverb | https://github.com/michaelwillis/dragonfly-reverb | A free hall-style reverb based on freeverb3 algorithms |
-| Mika Micro | https://github.com/tesselode/mika-micro | A simple subtractive synth plugin |
-| Cocoa Delay | https://github.com/tesselode/cocoa-delay | Warm and lively delay plugin |
-| Flutterbird | https://github.com/tesselode/flutterbird | Simple pitch fluctuation |
-| airwindows | https://github.com/airwindows/airwindows | Various small and experimental effect plugins |
-| regrader | https://github.com/igorski/regrader | A degenerative delay plugin |
-| OwlBass | https://github.com/PentagramPro/OwlBass | Additive bass synth |
-| Argotlunar | https://github.com/mourednik/argotlunar | Real-time delay-line granulator |
-| LameVST | https://github.com/Iunusov/LameVST | LameMP3 as an effect |
-| Dexed | https://github.com/asb2m10/dexed | DX7 FM plugin synth |
+| Plugin | Description |
+| --- | --- |
+| [mda](https://sourceforge.net/projects/mda-vst/) | A collection of FX and virtual instruments for PC and Mac |
+| [Synister](https://github.com/the-synister/the-source) | Subtractive software synth |
+| [Surge](https://surge-synthesizer.github.io/) | Subtractive wavetable synth |
+| [Eurorack](https://github.com/VCVRack/AudibleInstruments) | A diverse set of physical modeling sources, organic processors, wavetable oscillators, waveshapers, granular synthesizers, and utility modules |
+| [Helm](https://github.com/mtytel/helm) | a free polyphonic synth with lots of modulation |
+| [Dragonfly Reverb](https://github.com/michaelwillis/dragonfly-reverb) | A free hall-style reverb based on freeverb3 algorithms |
+| [Mika Micro](https://github.com/tesselode/mika-micro) | A simple subtractive synth plugin |
+| [Cocoa Delay](https://github.com/tesselode/cocoa-delay) | Warm and lively delay plugin |
+| [Flutterbird](https://github.com/tesselode/flutterbird) | Simple pitch fluctuation |
+| [airwindows](https://github.com/airwindows/airwindows) | Various small and experimental effect plugins |
+| [regrader](https://github.com/igorski/regrader) | A degenerative delay plugin |
+| [OwlBass](https://github.com/PentagramPro/OwlBass) | Additive bass synth |
+| [Argotlunar](https://github.com/mourednik/argotlunar) | Real-time delay-line granulator |
+| [LameVST](https://github.com/Iunusov/LameVST) | LameMP3 as an effect |
+| [Dexed](https://github.com/asb2m10/dexed) | DX7 FM plugin synth |
 
 Collections
 -----------
 
-* https://github.com/keithhearne/VSTPlugins
-* https://github.com/VCVRack
+* [keithhearne/VSTPlugins](https://github.com/keithhearne/VSTPlugins) — a number of VST plugins developed using the JUCE framework 
+* [VCVRack](https://github.com/VCVRack)
 
 Code Samples
 -----------
 
-https://github.com/HiFi-LoFi/KlangFalter
-https://github.com/HiFi-LoFi/FFTConvolver
+* [KlangFalter](https://github.com/HiFi-LoFi/KlangFalter) — a convolution audio plugin (e.g. for usage as convolution reverb)
+* [FFTConvolver](https://github.com/HiFi-LoFi/FFTConvolver) — an audio convolution algorithm in C++ for real time audio processing
 
 Open Data Resources
 -------------------
 
-Convolution Reverb Impulse Responses (to recreate reverb character of space and equipment/recordings)
-http://www.openairlib.net/
+[OpenAIR](http://www.openairlib.net/) — the Open Acoustic Impulse Response Library (Convolution Reverb Impulse Responses to recreate reverb character of space and equipment/recordings)
 
 Open Source Audio Apps
 ----------------------
 
-| Software | Website | Source |
+| Software | Source | Description |
 | --- | --- | --- |
-| Ardour: open source DAW | https://ardour.org/ | https://github.com/Ardour/ardour |
-| ASIO2WASAPI : universal ASIO driver for Windows | - |https://github.com/levmin/ASIO2WASAPI|
-| Audacity: open source audio editor | https://www.audacityteam.org/ | https://github.com/audacity/audacity |
-| FlexASIO: universal ASIO driver for Windows |  - | https://github.com/dechamps/FlexASIO |
-| Guitarix: GNU/Linux Virtual Amplifier | https://guitarix.org/ | https://sourceforge.net/projects/guitarix/ |
-| Helio Workstation: open source sequencer | https://helio.fm/ | https://github.com/helio-fm/helio-workstation |
-| OwlPlug: open source audio plugin manager | https://owlplug.com | https://github.com/DropSnorz/OwlPlug |
-| VCV Rack: open source modular synthesizer | https://vcvrack.com/ | https://github.com/VCVRack/Rack |
+| [Ardour](https://ardour.org/) | [Ardour/ardour](https://github.com/Ardour/ardour) | DAW |
+| ASIO2WASAPI | [levmin/ASIO2WASAPI](https://github.com/levmin/ASIO2WASAPI) | Universal ASIO driver for Windows |
+| [Audacity](https://www.audacityteam.org/) | [audacity/audacity](https://github.com/audacity/audacity) | Audio editor |
+| FlexASIO | [dechamps/FlexASIO](https://github.com/dechamps/FlexASIO) | Universal ASIO driver for Windows |
+| [Guitarix](https://guitarix.org/) | [SourceForge → guitarix](https://sourceforge.net/projects/guitarix/) | GNU/Linux Virtual Amplifier |
+| [Helio Workstation](https://helio.fm/) | [helio-fm/helio-workstation](https://github.com/helio-fm/helio-workstation) | Sequencer |
+| [OwlPlug](https://owlplug.com/) | [DropSnorz/OwlPlug](https://github.com/DropSnorz/OwlPlug) | Audio plugin manager |
+| [VCV Rack](https://vcvrack.com/) | [VCVRack/Rack](https://github.com/VCVRack/Rack) | Modular synthesizer |
 
 Open Source Software Development Libraries
 ----------------------
 
-| Name | Website | Source |
-| --- | --- | --- |
-|JUCE| https://juce.com | https://github.com/WeAreROLI/JUCE|
-|PortAudio| http://www.portaudio.com/ | https://app.assembla.com/spaces/portaudio/git/source |
-
-
+| Name | Source |
+| --- | --- |
+| [JUCE](https://juce.com/) | [WeAreROLI/JUCE](https://github.com/WeAreROLI/JUCE) |
+| [PortAudio](http://www.portaudio.com/) | [Assembla → portaudio](https://app.assembla.com/spaces/portaudio/git/source) |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Audio Plugins
 | [Dragonfly Reverb](https://github.com/michaelwillis/dragonfly-reverb) | A free hall-style reverb based on freeverb3 algorithms | DPF |
 | [Eurorack](https://github.com/VCVRack/AudibleInstruments) | A diverse set of physical modeling sources, organic processors, wavetable oscillators, waveshapers, granular synthesizers, and utility modules | ? |
 | [Flutterbird](https://github.com/tesselode/flutterbird) | Simple pitch fluctuation | iPlug 2 |
-| [Helm](https://github.com/mtytel/helm) | a free polyphonic synth with lots of modulation | JUCE |
+| [Helm](https://github.com/mtytel/helm) | A free polyphonic synth with lots of modulation | JUCE |
 | [LameVST](https://github.com/Iunusov/LameVST) | LameMP3 as an effect | ? |
 | [mda](https://sourceforge.net/projects/mda-vst/) | A collection of FX and virtual instruments for PC and Mac | ? |
 | [Mika Micro](https://github.com/tesselode/mika-micro) | A simple subtractive synth plugin | wdl-ol |

--- a/README.md
+++ b/README.md
@@ -15,21 +15,21 @@ Audio Plugins
 
 | Plugin | Description |
 | --- | --- |
-| [mda](https://sourceforge.net/projects/mda-vst/) | A collection of FX and virtual instruments for PC and Mac |
-| [Synister](https://github.com/the-synister/the-source) | Subtractive software synth |
-| [Surge](https://surge-synthesizer.github.io/) | Subtractive wavetable synth |
-| [Eurorack](https://github.com/VCVRack/AudibleInstruments) | A diverse set of physical modeling sources, organic processors, wavetable oscillators, waveshapers, granular synthesizers, and utility modules |
-| [Helm](https://github.com/mtytel/helm) | a free polyphonic synth with lots of modulation |
-| [Dragonfly Reverb](https://github.com/michaelwillis/dragonfly-reverb) | A free hall-style reverb based on freeverb3 algorithms |
-| [Mika Micro](https://github.com/tesselode/mika-micro) | A simple subtractive synth plugin |
-| [Cocoa Delay](https://github.com/tesselode/cocoa-delay) | Warm and lively delay plugin |
-| [Flutterbird](https://github.com/tesselode/flutterbird) | Simple pitch fluctuation |
 | [airwindows](https://github.com/airwindows/airwindows) | Various small and experimental effect plugins |
-| [regrader](https://github.com/igorski/regrader) | A degenerative delay plugin |
-| [OwlBass](https://github.com/PentagramPro/OwlBass) | Additive bass synth |
 | [Argotlunar](https://github.com/mourednik/argotlunar) | Real-time delay-line granulator |
-| [LameVST](https://github.com/Iunusov/LameVST) | LameMP3 as an effect |
+| [Cocoa Delay](https://github.com/tesselode/cocoa-delay) | Warm and lively delay plugin |
 | [Dexed](https://github.com/asb2m10/dexed) | DX7 FM plugin synth |
+| [Dragonfly Reverb](https://github.com/michaelwillis/dragonfly-reverb) | A free hall-style reverb based on freeverb3 algorithms |
+| [Eurorack](https://github.com/VCVRack/AudibleInstruments) | A diverse set of physical modeling sources, organic processors, wavetable oscillators, waveshapers, granular synthesizers, and utility modules |
+| [Flutterbird](https://github.com/tesselode/flutterbird) | Simple pitch fluctuation |
+| [Helm](https://github.com/mtytel/helm) | a free polyphonic synth with lots of modulation |
+| [LameVST](https://github.com/Iunusov/LameVST) | LameMP3 as an effect |
+| [mda](https://sourceforge.net/projects/mda-vst/) | A collection of FX and virtual instruments for PC and Mac |
+| [Mika Micro](https://github.com/tesselode/mika-micro) | A simple subtractive synth plugin |
+| [OwlBass](https://github.com/PentagramPro/OwlBass) | Additive bass synth |
+| [regrader](https://github.com/igorski/regrader) | A degenerative delay plugin |
+| [Surge](https://surge-synthesizer.github.io/) | Subtractive wavetable synth |
+| [Synister](https://github.com/the-synister/the-source) | Subtractive software synth |
 
 Collections
 -----------


### PR DESCRIPTION
* More compact / readable / usable linkification:
  - plugin title is now the link to the plugin site instead of providing the link plain text;
  - shorter text of GitHub source-code links in the form of `author/project`;
  - shorter text of non-GitHub links in the form of `hosting -> project`.
* Plugin description moved to a separate column.
* Added descriptions to the items in the "Collections" section.