### PR TITLE
Add link to MidiChords repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Audio Plugins
 | [Magical8bitPlug 2](https://github.com/yokemura/Magical8bitPlug2) | Old 8bit game console style synth | Instrument | JUCE
 | [mda](https://sourceforge.net/projects/mda-vst/) | FX and virtual instruments for PC and Mac | Misc | (no&nbsp;GUI) |
 | [mda-plugins-juce](https://github.com/hollance/mda-plugins-juce) | JUCE implementations of the classic MDA audio plug-ins | Misc | JUCE |
+| [MidiChords](https://github.com/markwilkins/midi-chord-reader) | Detect chord names from a MIDI track and display them in a scrolling window during track playback | Misc | JUCE |
 | [Mika Micro](https://github.com/tesselode/mika-micro) | Simple subtractive synth | Instrument | WDL-OL |
 | [MVerb](https://github.com/martineastwood/mverb) | Studio-quality reverb using the Dattorro’s figure-of-eight reverb structure | Effect | VSTGUI |
 | [Neural Amp Modeler LV2](https://github.com/mikeoliphant/neural-amp-modeler-lv2) | Neural amplifier modeler, LV2 version of Steven Atkinson's NAM plugin | Effect | no GUI |


### PR DESCRIPTION
Add an entry for open source repo MidiChords. It is a plugin built with JUCE. It is a MIDI-only plugin that detects the chords in a MIDI track and displays their names during playback in the DAW. 

This one seems different from the other plugins here in that it is not audio related. It is display only. So it might might not be appropriate for this list.