### PR TITLE
Dependabot: look for GitHub Actions third-party actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "github-actions"


### PR DESCRIPTION
## To turn on:

- Go to "Insights" --> "Dependency graph" --> "Dependabot" and turn on the bot.

## Update examples from the bot:

- https://github.com/satelllte/OpenAudio/pull/12
- https://github.com/satelllte/OpenAudio/pull/13
- https://github.com/satelllte/OpenAudio/pull/14