### PR TITLE
Update libraries.json with new entry: nallely (midi library)

### DIFF
--- a/data/libraries.json
+++ b/data/libraries.json
@@ -198,6 +198,15 @@
       "repo": "libspatialaudio"
     }
   },
+   {
+    "name": "Nallely",
+    "description": "Python library meta-synth oriented for scripting your MIDI devices, create virtual modules (LFOs, Envelope Generator, graphical visuals, ...), map all of them together dynamically. Also provides a websocket-bus to create visuals/modules with other languages and a websocket-based protocol to control the core library at run time.",
+    "repository": {
+      "type": "GitHub",
+      "user": "dr-schlange",
+      "repo": "nallely-midi"
+    }
+  },
   {
     "name": "NIH-plug",
     "description": "Rust VST3 and CLAP plugin framework and plugins",


### PR DESCRIPTION
This PR adds an entry for a new project: Nallely (https://github.com/dr-schlange/nallely-midi) which provides facilities to script MIDI devices in Python, create virtual devices that can expose parameters, and patch any parameter of any virtual/midi device together seemlessly. The library is written in Python, but a websocket-bus is proposed that lets you write modules or visuals in other technologies, that can auto-register and auto-expose their own parameters on which midi/virtual devices can map themselves. A websocket-based protocol (Trevor) lets you control at run time the bindings between devices as well as creating instances of the devices (midi and virtual). An experimental UI using Trevor to control the core library (Nallely) is also part of the project and will evolve.

The project is meta-synth oriented, the idea is to connect/interconnect various semi-modular/midi synths while controlling all of them at once and expanding their capabilities using software (virtual LFOs, virtual envelope generator), and binding them to remote visuals if required. Current visuals are coded in html/three.js.

The project is still quite new, but is evolving fast.