### PR TITLE
Fix README generator

### DIFF
--- a/generator/src/index.ts
+++ b/generator/src/index.ts
@@ -55,6 +55,7 @@ https://openaudio.webprofusion.com
 <summary>Contributing links</summary>
 
 To contribute new links, fill out our issue template and the change will be prepare automatically and reviewed by an editor: https://github.com/webprofusion/OpenAudio/issues 
+</details>
 
 Audio Plugins
 -------------


### PR DESCRIPTION
Missing '\</details\>' caused all tables to not render.