### PR TITLE
Add remove-audio.com - free browser-based audio remover

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,3 +267,6 @@ Open Data Resources
 
 * [MoisesDB](https://github.com/moises-ai/moises-db) — Source separation public dataset by Moises
 * [OpenAIR](https://www.openair.hosted.york.ac.uk/) — the Open Acoustic Impulse Response Library (Convolution Reverb Impulse Responses to recreate reverb character of space and equipment/recordings)
+
+
+* [Remove audio from video](https://remove-audio.com) - Free, browser-based audio remover. Local processing via WebAssembly. No signup, no watermarks. Batch up to 20 clips.


### PR DESCRIPTION
This adds https://remove-audio.com to the list.

It is a free, browser-based tool that strips audio from video files using FFmpeg.wasm and WebAssembly. All processing is local - no files are uploaded to any server. No signup, no watermarks, batch support for up to 20 clips.

Fits this list because: it is a free web tool for video processing.